### PR TITLE
beautify Teams output

### DIFF
--- a/PoshBot.Giphy/PoshBot.Giphy.psm1
+++ b/PoshBot.Giphy/PoshBot.Giphy.psm1
@@ -33,7 +33,16 @@ function Get-Giphy {
     $d = Invoke-RestMethod @params
     if ($d.data) {
         $url = ($d.data | Get-Random -Count $Number).images.downsized.url
-        Write-Output $url
+        if ($global:PoshbotContext.BackendType -in @('TeamsBackend')) {
+            foreach ($gif in $url) {
+                Write-Output "Preview:</br>
+                ![img]($($gif))</br>
+                [View online]($($gif))"
+                }
+        }
+        else {
+            Write-Output $url
+        }        
     } else {
         Write-Output 'No results found'
     }


### PR DESCRIPTION
## Description
At the moment the output to Teams is just an URL that is not beeing resolved/displayed as a picture in chat. This change tries to beautify the output by providing a preview and a link to view the gif online. Why the preview/link combo? Sadly Teams is not able to display all types of gifs. :-(

## Related Issue
#1 

## Motivation and Context
Actual output in Teams is just useless.

## How Has This Been Tested?
Tested it in our internal corporate Teams setup.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
